### PR TITLE
fix: discourage user verification for 2fa

### DIFF
--- a/lib/Service/WebauthnManager.php
+++ b/lib/Service/WebauthnManager.php
@@ -153,6 +153,12 @@ class WebauthnManager
         $excludedPublicKeyDescriptors = [
         ];
 
+        $authenticatorSelectionCriteria = new AuthenticatorSelectionCriteria(
+            AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE,
+            false,
+            AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_DISCOURAGED
+        );
+
         $publicKeyCredentialCreationOptions = new PublicKeyCredentialCreationOptions(
             $rpEntity,
             $userEntity,
@@ -160,7 +166,7 @@ class WebauthnManager
             $publicKeyCredentialParametersList,
             $timeout,
             $excludedPublicKeyDescriptors,
-            new AuthenticatorSelectionCriteria(),
+            $authenticatorSelectionCriteria,
             PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
             null
         );
@@ -297,7 +303,7 @@ class WebauthnManager
         $publicKeyCredentialRequestOptions
             ->setRpId($this->stripPort($serverHost))
             ->allowCredentials($registeredPublicKeyCredentialDescriptors)
-            ->setUserVerification(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_PREFERRED);
+            ->setUserVerification(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_DISCOURAGED);
 
         $this->session->set(self::TWOFACTORAUTH_WEBAUTHN_REQUEST, $publicKeyCredentialRequestOptions->jsonSerialize());
 


### PR DESCRIPTION
Sets `authenticatorSelection.userVerification` to `discouraged`, as this extension scope is to provide second-factor security and not to allow users to do a passwordless login (related issue https://github.com/nextcloud/server/issues/21215). Closes #41 